### PR TITLE
Improve link parser performance (mostly by removing `enum`)

### DIFF
--- a/wikitools/link_parser.py
+++ b/wikitools/link_parser.py
@@ -1,4 +1,3 @@
-import enum
 import typing
 from urllib import parse
 
@@ -26,7 +25,7 @@ class Brackets():
         return False
 
 
-class State(enum.Enum):
+class State:
     IDLE = 0
     START = 1
     INLINE = 2
@@ -158,7 +157,7 @@ def find_link(s: str, index=0) -> typing.Optional[Link]:
                 # the end of a bracket. the link may continue
                 # to be inline- or reference-style
                 if len(s) <= i + 1:
-                    state = state.IDLE
+                    state = State.IDLE
                     continue
 
                 if s[i + 1] == '(':
@@ -168,7 +167,7 @@ def find_link(s: str, index=0) -> typing.Optional[Link]:
                     state = State.REFERENCE
                     location = i + 2
                 else:
-                    state = state.IDLE
+                    state = State.IDLE
             continue
 
         if state == State.INLINE:

--- a/wikitools/link_parser.py
+++ b/wikitools/link_parser.py
@@ -144,7 +144,8 @@ def find_link(s: str, index=0) -> typing.Optional[Link]:
     parens = Brackets('(', ')')
     brackets = Brackets('[', ']')
 
-    for i, c in enumerate(s[index:], start=index):
+    for i in range(index, len(s)):
+        c = s[i]
         if state == State.IDLE and c == '[':
             # potential start of a link
             brackets.depth += 1


### PR DESCRIPTION
benchmarked by running the following in `zsh`, where `time` is a keyword which makes output suppression easier:

```shell
(venv) /home/user/stuff/osu-wiki % for _ in {0..9}; do time ( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all >/dev/null 2>/dev/null ); done
```

## results (sorted asc)

<details>
<summary>baseline</summary>

```
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  18.59s user 0.28s system 99% cpu 18.869 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  18.74s user 0.26s system 99% cpu 19.000 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  18.92s user 0.28s system 99% cpu 19.205 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  18.93s user 0.32s system 99% cpu 19.272 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  18.95s user 0.29s system 99% cpu 19.242 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  19.03s user 0.24s system 99% cpu 19.278 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  19.14s user 0.35s system 99% cpu 19.492 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  19.16s user 0.21s system 99% cpu 19.367 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  19.30s user 0.25s system 99% cpu 19.554 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  19.33s user 0.35s system 99% cpu 19.681 total
```

</details>

<details>
<summary>without `enum`</summary>

```
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.24s user 0.28s system 99% cpu 12.534 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.35s user 0.29s system 99% cpu 12.657 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.36s user 0.27s system 99% cpu 12.629 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.41s user 0.21s system 99% cpu 12.629 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.42s user 0.26s system 99% cpu 12.686 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.50s user 0.25s system 99% cpu 12.754 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.57s user 0.17s system 99% cpu 12.742 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.68s user 0.23s system 99% cpu 12.922 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.71s user 0.16s system 99% cpu 12.875 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.81s user 0.17s system 99% cpu 12.980 total
```

</details>

<details>
<summary>without `enum` and string copying</summary>

```
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.30s user 0.16s system 99% cpu 12.474 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.35s user 0.14s system 99% cpu 12.490 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.36s user 0.22s system 99% cpu 12.576 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.38s user 0.11s system 99% cpu 12.489 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.39s user 0.19s system 99% cpu 12.585 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.39s user 0.24s system 99% cpu 12.630 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.45s user 0.18s system 99% cpu 12.651 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.46s user 0.10s system 99% cpu 12.558 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.46s user 0.20s system 99% cpu 12.664 total
( python ~/stuff/osu-wiki-tools/find-broken-wikilinks.py --all > /dev/null 2>)  12.56s user 0.20s system 99% cpu 12.771 total
```

</details>