### PR TITLE
Consider articles outdated if their front matter contains `outdated: true`

### DIFF
--- a/tests/test_check_outdated_articles.py
+++ b/tests/test_check_outdated_articles.py
@@ -110,6 +110,36 @@ class TestCheckOutdatedArticles:
 
         assert multiset(translations_to_outdate) == multiset(utils.remove(article_paths, "en.md"))
 
+    def test__list_outdated_translations__no_specific_hash(self, root):
+        utils.set_up_dummy_repo()
+        article_paths = [
+            'wiki/Article/en.md',
+            'wiki/Article/fr.md',
+            'wiki/Article/pt-br.md',
+            'wiki/Article/zh-tw.md',
+        ]
+
+        utils.create_files(root, *((path, '# Article') for path in article_paths[:-1]))
+
+        zh_tw_contents = textwrap.dedent("""
+        ---
+        outdated: true
+        ---
+
+        # Article
+        """)
+        utils.create_files(root, (article_paths[-1], zh_tw_contents))
+        utils.stage_all_and_commit("add some articles")
+
+        utils.create_files(root, (article_paths[0], '# Article\n\nThis is an article in English.'))
+        utils.stage_all_and_commit("add english article content")
+        translations_to_outdate = list(outdater.list_outdated_translations(
+            set(utils.remove(article_paths, "en.md")),
+            set()
+        ))
+
+        assert multiset(translations_to_outdate) == multiset(utils.remove(article_paths, "en.md", "zh-tw.md"))
+
     def test__outdate_translations(self, root):
         utils.set_up_dummy_repo()
         article_paths = [

--- a/wikitools_cli/commands/check_outdated_articles.py
+++ b/wikitools_cli/commands/check_outdated_articles.py
@@ -26,6 +26,9 @@ OUTDATED_TRANSLATION_TAG = "outdated_translation"
 # The front matter tag which contains the commit hash since which the translation is not up to date
 OUTDATED_HASH_TAG = "outdated_since"
 
+# The front matter tag which shows that the article is outdated since some unknown moment of time
+OUTDATED_TAG = "outdated"
+
 # The script flag which will automatically outdate translations
 AUTOFIX_FLAG = "--autofix"
 AUTOFIX_FLAG_SHORT = "-f"
@@ -90,7 +93,11 @@ def list_outdated_translations(all_translations, modified_translations):
 
         with open(article_file, "r", encoding='utf-8') as fd:
             front_matter = article_parser.load_front_matter(fd)
-        if OUTDATED_HASH_TAG in front_matter or front_matter.get(OUTDATED_TRANSLATION_TAG, False):
+        if (
+            OUTDATED_HASH_TAG in front_matter or
+            front_matter.get(OUTDATED_TRANSLATION_TAG, False) or
+            front_matter.get(OUTDATED_TAG, False)
+        ):
             continue
 
         yield article_file


### PR DESCRIPTION
found this in https://github.com/ppy/osu-wiki/pull/8462 -- the check shouldn't have failed (https://github.com/ppy/osu-wiki/actions/runs/3685605919/jobs/6236777617)