### PR TITLE
Change behavior of `--base-commit` and `--outdated-since` options

### DIFF
--- a/tests/test_check_outdated_articles.py
+++ b/tests/test_check_outdated_articles.py
@@ -37,10 +37,8 @@ class TestCheckOutdatedArticles:
 
         utils.create_files(root, *((path, '# Article') for path in article_paths))
         utils.stage_all_and_commit("add article title")
-        commit_hash = utils.get_last_commit_hash()
 
-        # note that at least two existing commits are necessary to get a diff using `revision^`
-        modified_translations = outdater.list_modified_translations(commit_hash)
+        modified_translations = outdater.list_modified_translations("HEAD^")
 
         assert multiset(modified_translations) == multiset(utils.remove(article_paths, "en.md", "TEMPLATE.md"))
 
@@ -49,9 +47,8 @@ class TestCheckOutdatedArticles:
             utils.take(article_paths, "fr.md"))
         )
         utils.stage_all_and_commit("add article content")
-        commit_hash = utils.get_last_commit_hash()
 
-        modified_translations = outdater.list_modified_translations(commit_hash)
+        modified_translations = outdater.list_modified_translations("HEAD^")
 
         assert multiset(modified_translations) == multiset(utils.take(article_paths, "fr.md"))
 
@@ -70,16 +67,14 @@ class TestCheckOutdatedArticles:
 
         utils.create_files(root, *((path, '# Article') for path in article_paths))
         utils.stage_all_and_commit("add some articles")
-        commit_hash = utils.get_last_commit_hash()
 
         utils.create_files(root, *zip(article_paths[0:2], [
             '# Article\n\nThis is an article in English.',
             '# Article\n\nThis is another article in English.',
         ]))
         utils.stage_all_and_commit("add article content")
-        commit_hash = utils.get_last_commit_hash()
 
-        modified_originals = outdater.list_modified_originals(commit_hash)
+        modified_originals = outdater.list_modified_originals("HEAD^")
         assert multiset(modified_originals) == multiset(utils.take(article_paths, "en.md"))
 
     def test__list_outdated_translations(self, root):
@@ -223,7 +218,7 @@ class TestCheckOutdatedArticles:
         utils.stage_all_and_commit("modify english articles")
         commit_hash_2 = utils.get_last_commit_hash()
 
-        exit_code = outdater.main("--base-commit", commit_hash_2, f"{outdater.AUTOFIX_FLAG}")
+        exit_code = outdater.main("--base-commit", "HEAD^", "--outdated-since", commit_hash_2, f"{outdater.AUTOFIX_FLAG}")
 
         assert exit_code == 0
 
@@ -300,17 +295,15 @@ class TestCheckOutdatedArticles:
         utils.stage_all_and_commit("modify english articles")
         commit_hash_2 = utils.get_last_commit_hash()
 
-        exit_code = outdater.main("--base-commit", commit_hash_2, f"{outdater.AUTOFIX_FLAG}", f"{outdater.AUTOCOMMIT_FLAG}")
+        exit_code = outdater.main("--base-commit", "HEAD^", "--outdated-since", commit_hash_2, f"{outdater.AUTOFIX_FLAG}", f"{outdater.AUTOCOMMIT_FLAG}")
 
         assert exit_code == 0
 
-        commit_hash_3 = utils.get_last_commit_hash()
-
-        assert commit_hash_3 != commit_hash_2
+        assert commit_hash_2 != utils.get_last_commit_hash()
 
         assert utils.get_changed_files() == []
 
-        outdated_translations = outdater.list_modified_translations(commit_hash_3)
+        outdated_translations = outdater.list_modified_translations("HEAD^")
 
         non_chinese_translations = utils.remove(article_paths, "en.md", "zh-tw.md")
 
@@ -384,7 +377,7 @@ class TestCheckOutdatedArticles:
         commit_hash_2 = utils.get_last_commit_hash()
 
         cd = file_utils.ChangeDirectory("wiki")
-        exit_code = outdater.main("--root", "..", "--base-commit", commit_hash_2, f"{outdater.AUTOFIX_FLAG}")
+        exit_code = outdater.main("--root", "..", "--base-commit", "HEAD^", "--outdated-since", commit_hash_2, f"{outdater.AUTOFIX_FLAG}")
         del cd
 
         assert exit_code == 0
@@ -463,18 +456,16 @@ class TestCheckOutdatedArticles:
         commit_hash_2 = utils.get_last_commit_hash()
 
         cd = file_utils.ChangeDirectory("wiki")
-        exit_code = outdater.main("--root", "..", "--base-commit", commit_hash_2, f"{outdater.AUTOFIX_FLAG}", f"{outdater.AUTOCOMMIT_FLAG}")
+        exit_code = outdater.main("--root", "..", "--base-commit", "HEAD^", "--outdated-since", commit_hash_2, f"{outdater.AUTOFIX_FLAG}", f"{outdater.AUTOCOMMIT_FLAG}")
         del cd
 
         assert exit_code == 0
 
-        commit_hash_3 = utils.get_last_commit_hash()
-
-        assert commit_hash_3 != commit_hash_2
+        assert commit_hash_2 != utils.get_last_commit_hash()
 
         assert utils.get_changed_files() == []
 
-        outdated_translations = outdater.list_modified_translations(commit_hash_3)
+        outdated_translations = outdater.list_modified_translations("HEAD^")
 
         non_chinese_translations = utils.remove(article_paths, "en.md", "zh-tw.md")
 

--- a/wikitools/git_utils.py
+++ b/wikitools/git_utils.py
@@ -20,7 +20,7 @@ def git(*args, expected_code=0):
 
 
 def git_diff(*file_paths, base_commit=""):
-    res = git("diff", "--diff-filter=d", "--name-only", f"{base_commit}^", "--", *file_paths)
+    res = git("diff", "--diff-filter=d", "--name-only", base_commit, "--", *file_paths)
     return res.splitlines()
 
 

--- a/wikitools_cli/commands/check_outdated_articles.py
+++ b/wikitools_cli/commands/check_outdated_articles.py
@@ -71,7 +71,7 @@ def print_bad_hash_error(*filenames, outdated_hash=None):
 
 def parse_args(args):
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter, usage="%(prog)s check-outdated-articles [options]")
-    parser.add_argument("-b", "--base-commit", help="commit since which to look for changes")
+    parser.add_argument("-b", "--base-commit", default="master", help="commit since which to look for changes")
     parser.add_argument("-o", "--outdated-since", default="", help=f"commit hash for the {OUTDATED_HASH_TAG} tag, uses the value of --base-commit if unspecified")
     parser.add_argument("-a", "--all", default=False, action="store_true", help="look for incorrect hashes in all outdated articles")
     parser.add_argument(f"{AUTOFIX_FLAG_SHORT}", f"{AUTOFIX_FLAG}", default=False, action="store_true", help=f"automatically add `{OUTDATED_HASH_TAG}: {{hash}}` to outdated articles")
@@ -151,41 +151,27 @@ def main(*args):
     if args.root:
         changed_cwd = file_utils.ChangeDirectory(args.root)
 
-    base_commit = args.base_commit or git_utils.get_first_branch_commit()
-
-    if not base_commit and not args.all:
-        print(f"{console.red('Error:')} neither --base-commit (unable to obtain automatically) nor --all were specified; nothing to do.")
-        exit_code = 1
-        if args.root:
-            del changed_cwd
-        return exit_code
-
     modified_translations = set()
     with_bad_hashes = list()
 
-    if not args.all and base_commit:
-        modified_translations = set(list_modified_translations(base_commit))
-        with_bad_hashes = list(check_commit_hashes(modified_translations))
-    elif args.all:
+    if args.all:
         all_translations = file_utils.list_all_translations(file_utils.list_all_article_dirs())
         with_bad_hashes = list(check_commit_hashes(all_translations))
+    else:
+        modified_translations = set(list_modified_translations(args.base_commit))
+        with_bad_hashes = list(check_commit_hashes(modified_translations))
 
     if with_bad_hashes:
-        print_bad_hash_error(*with_bad_hashes, outdated_hash=args.outdated_since or base_commit)
+        print_bad_hash_error(*with_bad_hashes, outdated_hash=args.outdated_since or args.base_commit)
         print()
         exit_code = 1
 
-    if not base_commit:
-        if args.root:
-            del changed_cwd
-        return exit_code
-
-    modified_originals = list_modified_originals(base_commit)
+    modified_originals = list_modified_originals(args.base_commit)
     if modified_originals:
         all_translations = file_utils.list_all_translations(sorted(os.path.dirname(tl) for tl in modified_originals))
         translations_to_outdate = list(list_outdated_translations(all_translations, modified_translations))
         if translations_to_outdate:
-            outdated_hash = args.outdated_since or base_commit
+            outdated_hash = args.outdated_since or args.base_commit
 
             should_autofix = getattr(args, AUTOFIX_FLAG[2:], False)
             should_autocommit = getattr(args, AUTOCOMMIT_FLAG[2:], False)


### PR DESCRIPTION
- `--base-commit` now defaults to `master` and behaves as a true base commit, not one-commit-after-the-base-commit
- `--outdated-since` now defaults to first commit diverging from `master` (i.e. the old `--base-commit` default)

this allows flexibility to cover the case I mentioned on Discord, and the defaults should cover every normal case of working on a PR, as well as CI and `run_checks`

I'm not sure what `outdate_translations` is supposed to do if `outdated_hash` is `None`. also maybe tests for the defaults would be good but I'm not sure best way to write that