### PR TITLE
Allow to ignore outdated articles using `--exclude`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ pip install osu-wiki-tools
 
 ### Setup
 
+Install Python C API headers (required for building the `pynput` dependency):
+
+```sh
+apt install python3-dev
+```
+
+Create the virtual enviroment:
+
 ```sh
 python3 -m venv ./venv
 source ./venv/bin/activate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+braceexpand==0.1.7
 mypy==0.991
 pynput==1.7.6
 pytest-mock==3.10.0

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,6 @@ setuptools.setup(
         "PyYAML==6.0.1",
         "types-PyYAML==6.0.12.12",
         "yamllint==1.33.0",
+        "braceexpand==0.1.7",
     ],
 )

--- a/tests/test_check_outdated_articles.py
+++ b/tests/test_check_outdated_articles.py
@@ -529,7 +529,6 @@ class TestCheckOutdatedArticles:
 
         assert utils.get_changed_files() == []
 
-
     @pytest.mark.parametrize(
         "exclude_args,expected_changed_files",
         [
@@ -542,7 +541,7 @@ class TestCheckOutdatedArticles:
                 # Expect
                 [
                     "wiki/First_article/zh-tw.md",
-                    
+
                     'wiki/Second_article/fr.md',
                     'wiki/Second_article/pt-br.md',
                     'wiki/Second_article/zh-tw.md',
@@ -640,7 +639,6 @@ class TestCheckOutdatedArticles:
             utils.take(article_paths, "en.md")
         ))
         utils.stage_all_and_commit("modify english articles")
-
 
         exit_code = outdater.main(
             "--autofix",

--- a/tests/test_check_outdated_articles.py
+++ b/tests/test_check_outdated_articles.py
@@ -1,6 +1,7 @@
 from collections import Counter as multiset
 import textwrap
 
+import pytest
 import tests.utils as utils
 
 from wikitools import article_parser, git_utils, file_utils
@@ -527,3 +528,126 @@ class TestCheckOutdatedArticles:
         assert exit_code == 1
 
         assert utils.get_changed_files() == []
+
+
+    @pytest.mark.parametrize(
+        "exclude_args,expected_changed_files",
+        [
+            pytest.param(
+                # Given
+                [
+                    "--exclude", "wiki/First_article/fr.md",
+                    "--exclude", "wiki/First_article/pt-br.md",
+                ],
+                # Expect
+                [
+                    "wiki/First_article/zh-tw.md",
+                    
+                    'wiki/Second_article/fr.md',
+                    'wiki/Second_article/pt-br.md',
+                    'wiki/Second_article/zh-tw.md',
+                ],
+                id="Single file paths",
+            ),
+
+            pytest.param(
+                # Given
+                [
+                    "--exclude", "wiki/First_article",
+                ],
+                # Expect
+                [
+                    'wiki/Second_article/fr.md',
+                    'wiki/Second_article/pt-br.md',
+                    'wiki/Second_article/zh-tw.md',
+                ],
+                id="Directory paths",
+            ),
+
+            pytest.param(
+                # Given
+                [
+                    "--exclude", "wiki/*/fr.md",
+                ],
+                # Expect
+                [
+                    'wiki/First_article/pt-br.md',
+                    'wiki/First_article/zh-tw.md',
+
+                    'wiki/Second_article/pt-br.md',
+                    'wiki/Second_article/zh-tw.md',
+                ],
+                id="Fnmatch masks (only star patterns)"
+            ),
+
+            pytest.param(
+                # Given
+                [
+                    "--exclude", "wiki/{First_article,Second_article}/pt-br.md",
+                    "--exclude", "wiki/First_article/{fr,zh-tw}.md",
+                ],
+                # Expect
+                [
+                    'wiki/Second_article/fr.md',
+                    'wiki/Second_article/zh-tw.md',
+                ],
+                id="Shell brace expansion"
+            ),
+
+            pytest.param(
+                # Given
+                [
+                    "--exclude", "no/match",
+                    "--exclude", "wiki/fr.md",
+                    "--exclude", "wiki/First_art",
+                    "--exclude", "wiki/Second_article/es.md",
+                    "--exclude", "wiki/Second_article/en.md",
+                    "--exclude", "wiki/{First_article,Second_article}/jp.md",
+                ],
+                # Expect
+                [
+                    'wiki/First_article/fr.md',
+                    'wiki/First_article/pt-br.md',
+                    'wiki/First_article/zh-tw.md',
+
+                    'wiki/Second_article/fr.md',
+                    'wiki/Second_article/pt-br.md',
+                    'wiki/Second_article/zh-tw.md',
+                ],
+                id="No valid matches"
+            ),
+        ]
+    )
+    def test__exclude_articles_from_check(self, root, exclude_args, expected_changed_files):
+        utils.set_up_dummy_repo()
+        article_paths = [
+            'wiki/First_article/en.md',
+            'wiki/First_article/fr.md',
+            'wiki/First_article/pt-br.md',
+            'wiki/First_article/zh-tw.md',
+
+            'wiki/Second_article/en.md',
+            'wiki/Second_article/fr.md',
+            'wiki/Second_article/pt-br.md',
+            'wiki/Second_article/zh-tw.md',
+        ]
+
+        utils.create_files(root, *((path, '# Article') for path in article_paths))
+        utils.stage_all_and_commit("add articles")
+
+        utils.create_files(root, *(
+            (article_path, '# Article\n\nThis is an article in English.') for article_path in
+            utils.take(article_paths, "en.md")
+        ))
+        utils.stage_all_and_commit("modify english articles")
+
+
+        exit_code = outdater.main(
+            "--autofix",
+            "--base-commit", "HEAD^",
+            "--outdated-since", "HEAD^",
+            *exclude_args
+        )
+
+        assert exit_code == 0
+        assert utils.get_changed_files() == expected_changed_files

--- a/wikitools_cli/commands/check_outdated_articles.py
+++ b/wikitools_cli/commands/check_outdated_articles.py
@@ -169,7 +169,7 @@ def path_match(file_path: str, patterns: list[str]) -> bool:
         for path_or_mask in patterns:
             if (
                 article_path == path_or_mask
-                or os.path.commonpath((article_path, path_or_mask)) == path_or_mask
+                or os.path.commonpath((article_path, path_or_mask)).replace("\\", "/") == path_or_mask
                 or fnmatch.fnmatch(article_path, path_or_mask)
             ):
                 return True

--- a/wikitools_cli/commands/check_outdated_articles.py
+++ b/wikitools_cli/commands/check_outdated_articles.py
@@ -13,11 +13,14 @@ Alternatively, it can be run with --autofix (and --autocommit, or just -fc) to o
 
 import argparse
 import fnmatch
+import itertools
 import os
 import os.path
 import sys
 
 from wikitools import article_parser, console, git_utils, file_utils
+
+import braceexpand
 
 # A pull request string which disables the check (has no effect here, listed for informational purposes only)
 PULL_REQUEST_TAG = "SKIP_OUTDATED_CHECK"
@@ -80,7 +83,7 @@ def parse_args(args):
     parser.add_argument(f"{AUTOFIX_FLAG_SHORT}", f"{AUTOFIX_FLAG}", default=False, action="store_true", help=f"automatically add `{OUTDATED_HASH_TAG}: {{hash}}` to outdated articles")
     parser.add_argument(f"{AUTOCOMMIT_FLAG_SHORT}", f"{AUTOCOMMIT_FLAG}", default=False, action="store_true", help="automatically commit changes")
     parser.add_argument("-r", "--root", help="specify repository root, current working directory assumed otherwise")
-    parser.add_argument("-e", "--exclude", default=[], nargs='*', help="list of paths to exclude from checking (accepts file paths, directories, and shell patterns)")
+    parser.add_argument("-e", "--exclude", action='append', help="list of paths to exclude from checking (accepts file paths, directories, and shell patterns)")
     parser.add_argument("--no-recommend-autofix", action='store_true', help=f"don't recommend rerunning the script with {AUTOFIX_FLAG}")
     return parser.parse_args(args)
 
@@ -148,6 +151,31 @@ def check_commit_hashes(modified_translations):
             yield article_file
 
 
+def path_match(file_path: str, patterns: list[str]) -> bool:
+    """
+    Check if a file path matches one or more patterns that exclude it from the outdated check.
+
+    Patterns may look like this, with the wiki/ prefix optionally omitted:
+
+      - Individual articles: wiki/Path/To/Article/en.md
+      - Article directories: wiki/Article
+      - Fnmatch masks: wiki/*/es.md
+      - Paths with shell-style brace expansion:
+        - wiki/{Article,Other_article}/es.md
+        - wiki/{Article,Other_article}/{es,jp}.md
+    """
+
+    for article_path in [file_path, file_path.removeprefix("wiki/")]:
+        for path_or_mask in patterns:
+            if (
+                article_path == path_or_mask
+                or os.path.commonpath((article_path, path_or_mask)) == path_or_mask
+                or fnmatch.fnmatch(article_path, path_or_mask)
+            ):
+                return True
+    return False
+
+
 def main(*args):
     args = parse_args(args)
     exit_code = 0
@@ -181,19 +209,15 @@ def main(*args):
         translations_to_outdate = []
         if args.exclude:
             excluded_count = 0
-            for translation in temp_translations_to_outdate:
-                any_matched = False
-                for path_or_mask in args.exclude:
-                    if (
-                        translation == path_or_mask
-                        or os.path.commonpath((translation, path_or_mask)) == path_or_mask
-                        or fnmatch.fnmatch(translation, path_or_mask)
-                    ):
-                        any_matched = True
-                        excluded_count += 1
-                        break
+            masks = list(itertools.chain(*map(
+                lambda single_argument: list(braceexpand.braceexpand(single_argument)),
+                args.exclude
+            )))
 
-                if not any_matched:
+            for translation in temp_translations_to_outdate:
+                if path_match(translation, masks):
+                    excluded_count += 1
+                else:
                     translations_to_outdate.append(translation)
             print(f"{excluded_count} of {len(temp_translations_to_outdate)} translation(s) skipped due to --exclude")
         else:


### PR DESCRIPTION
this is chasing https://discord.com/channels/188630481301012481/218677502141399041/1382027487634133182 -- I imagine it should work as follows:

- a contributor changes the PR's description prior to merge, listing paths that should not be outdated, example:
```
# specific file
DO_NOT_OUTDATE: wiki/BanchoBot/fr.md

# all files in a directory
DO_NOT_OUTDATE: wiki/Article_styling_criteria

# all Indonesian translations
DO_NOT_OUTDATE: wiki/*/id.md

# all translations
DO_NOT_OUTDATE: wiki/

# several masks in a row
DO_NOT_OUTDATE: wiki/Beatmap/fr.md, wiki/osu!supporter/fr.md, wiki/Gameplay/*/fr.md
``` 
- a CI action runs post-merge and reads a list of files from the PR's description
  - it runs `osu-wiki-tools check-outdated-articles --autofix --autocommit --exclude <path or mask 1> --exclude <path or mask 2>`
  - it pushes the commit to `master`