### PR TITLE
Speed up the link checker by caching different small things

### DIFF
--- a/wikitools/code_block_parser.py
+++ b/wikitools/code_block_parser.py
@@ -46,14 +46,15 @@ class CodeBlockParser:
     def in_multiline(self) -> bool:
         return self.__in_multiline
 
-    def count_tag_length(self, line: str, pos: int) -> int:
+    def count_tag_length(self, line: str, pos: int, line_len: int) -> int:
         tag_len = 0
-        while pos + tag_len < len(line) and line[pos + tag_len] == '`':
+        while pos + tag_len < line_len and line[pos + tag_len] == '`':
             tag_len += 1
         return tag_len
 
     def parse(self, line: str) -> typing.List[CodeBlock]:
         blocks: typing.List[CodeBlock] = []
+        line_len = len(line)
 
         if line.startswith('```'):
             if self.__in_multiline:
@@ -63,7 +64,7 @@ class CodeBlockParser:
                     return [CodeBlock(start=-1, end=-1)]
             else:
                 # opening a multiline block
-                self.__multiline_tag = '`' * self.count_tag_length(line, 0)
+                self.__multiline_tag = '`' * self.count_tag_length(line, 0, line_len)
                 self.__in_multiline = True
                 return [CodeBlock(start=-1, end=-1)]
 
@@ -71,12 +72,12 @@ class CodeBlockParser:
             return [CodeBlock(start=-1, end=-1)]
 
         i = 0
-        while i < len(line):
+        while i < line_len:
             if line[i] != '`':
                 i += 1
                 continue
 
-            tag_len = self.count_tag_length(line, i)
+            tag_len = self.count_tag_length(line, i, line_len)
 
             # the next tag of the same length will close the block
             closing_tag = re.search(

--- a/wikitools/file_utils.py
+++ b/wikitools/file_utils.py
@@ -43,7 +43,7 @@ def get_canonical_path_casing(path: pathlib.Path) -> pathlib.Path:
     The path must exist (throws KeyError otherwise)
     """
 
-    return pathlib.Path(file_tree()[normalised(os.path.relpath(path.as_posix()).lower())])
+    return pathlib.Path(file_tree()[normalised(path.as_posix()).lower()])
 
 
 def exists_case_sensitive(path: pathlib.Path) -> bool:
@@ -71,7 +71,7 @@ def exists_case_insensitive(path: pathlib.Path) -> bool:
     else:
         # case-insensitive directory/file existence checking isn't trivial in case-sensitive file systems because os-provided existence checks can't be relied upon
 
-        return normalised(os.path.relpath(path.as_posix()).lower()) in file_tree()
+        return normalised(path.as_posix()).lower() in file_tree()
 
 
 def is_newspost(path: str) -> bool:

--- a/wikitools/identifier_parser.py
+++ b/wikitools/identifier_parser.py
@@ -37,19 +37,20 @@ def extract_identifier(
     The burden of checking for the comments and code blocks lies on the caller.
     """
 
-    for i in range(len(s)):
+    s_len = len(s)
+    for i in range(s_len):
         if s[i] == '{':
             # could be an identifier -- check if there are any meaningful prefixes ahead
             id_start = None
             for prefix in ID_PREFIXES:
                 id_start = i + 1 + len(prefix)
-                if id_start >= len(s) or s[i + 1: id_start] != prefix:
+                if id_start >= s_len or s[i + 1: id_start] != prefix:
                     continue
 
                 j = id_start
-                while j < len(s) and s[j] != '}':
+                while j < s_len and s[j] != '}':
                     j += 1
-                if j < len(s) and s[j] == '}':
+                if j < s_len and s[j] == '}':
                     return (s[id_start: j], id_start)
 
     # skip regular lines and article titles (no one refers to them)
@@ -58,7 +59,7 @@ def extract_identifier(
 
     # skip to the actual heading
     j = 0
-    while j < len(s) and s[j] in ('#', ' '):
+    while j < s_len and s[j] in ('#', ' '):
         j += 1
 
     # headings can contain figures or formatting, but ASC disallows the latter.

--- a/wikitools/link_parser.py
+++ b/wikitools/link_parser.py
@@ -127,7 +127,6 @@ def find_link(s: str, index=0) -> typing.Optional[Link]:
     location = -1
     extra = None
 
-    # Bracket/paren depth counters inlined to avoid method call overhead
     bracket_depth = 0
     paren_depth = 0
 

--- a/wikitools/link_parser.py
+++ b/wikitools/link_parser.py
@@ -7,32 +7,11 @@ from wikitools import console, reference_parser
 _urlparse = lru_cache(maxsize=4096)(parse.urlparse)
 
 
-class Brackets():
-    # Helper class keeping track of when brackets open and close
-    def __init__(self, left: str, right: str):
-        self.left = left
-        self.right = right
-        self.depth = 0
-
-    left: str
-    right: str
-    depth: int
-
-    def closed(self, c: str):
-        if c == self.left:
-            self.depth += 1
-        elif c == self.right:
-            self.depth -= 1
-        if self.depth == 0:
-            return True
-        return False
-
-
-class State:
-    IDLE = 0
-    START = 1
-    INLINE = 2
-    REFERENCE = 3
+# State constants inlined to avoid attribute lookups
+_STATE_IDLE = 0  # IDLE: jump to next '[' using optimized str.find
+_STATE_START = 1  # START: tracking bracket depth inline
+_STATE_INLINE = 2  # INLINE: tracking paren depth inline
+_STATE_REFERENCE = 3  # REFERENCE: tracking bracket depth inline
 
 
 class Link(typing.NamedTuple):
@@ -142,94 +121,121 @@ def find_link(s: str, index=0) -> typing.Optional[Link]:
         - [alt_text][reference], with exact locations found separately via find_reference()
     """
 
-    state = State.IDLE
+    state = _STATE_IDLE
 
     start = -1
     location = -1
     extra = None
-    end = None
 
-    parens = Brackets('(', ')')
-    brackets = Brackets('[', ']')
+    # Bracket/paren depth counters inlined to avoid method call overhead
+    bracket_depth = 0
+    paren_depth = 0
 
     s_len = len(s)
-    for i in range(index, s_len):
-        c = s[i]
-        if state == State.IDLE and c == '[':
+    i = index
+
+    while i < s_len:
+        if state == _STATE_IDLE:
+            i = s.find('[', i)
+            if i == -1:
+                return None
+
             # potential start of a link
-            brackets.depth += 1
-            state = State.START
+            bracket_depth = 1
+            state = _STATE_START
             start = i
+            i += 1
             continue
 
-        if state == State.START:
-            if brackets.closed(c):
+        c = s[i]
+
+        if state == _STATE_START:
+            if c == '[':
+                bracket_depth += 1
+            elif c == ']':
+                bracket_depth -= 1
+            if bracket_depth == 0:
                 if s_len <= i + 1:
                     # end of the line
-                    state = State.IDLE
+                    state = _STATE_IDLE
+                    i += 1
                     continue
 
                 if s[start + 1] == '^':
                     # found a footnote -> ignore
-                    state = State.IDLE
+                    state = _STATE_IDLE
+                    i += 1
                     continue
 
                 # the end of a bracket. the link may continue
                 # to be inline- or reference-style
                 if s[i + 1] == '(':
-                    state = State.INLINE
+                    state = _STATE_INLINE
                     location = i + 2
+                    paren_depth = 0
                 elif s[i + 1] == '[':
-                    if s[i + 2] == '^':
+                    if i + 2 < s_len and s[i + 2] == '^':
                         # found a footnote after bracket pair -> ignore
-                        state = State.IDLE
+                        state = _STATE_IDLE
+                        i += 1
                         continue
 
-                    state = State.REFERENCE
+                    state = _STATE_REFERENCE
                     location = i + 2
+                    bracket_depth = 0
                 else:
-                    state = State.IDLE
+                    state = _STATE_IDLE
+            i += 1
             continue
 
-        if state == State.INLINE:
+        if state == _STATE_INLINE:
             if c == ' ':
                 if extra is None:
-                    # start of extra part
                     extra = i
 
-            if parens.closed(c):
+            if c == '(':
+                paren_depth += 1
+            elif c == ')':
+                paren_depth -= 1
+            if paren_depth == 0:
                 # end of a complete link
-                end = i
                 if extra is None:
-                    extra = end
+                    extra = i
 
                 raw_location = s[location: extra]
                 return Link(
                     raw_location=raw_location,
                     parsed_location=_urlparse(raw_location),
                     alt_text=s[start + 1: location - 2],
-                    title=s[extra: end],
+                    title=s[extra: i],
                     start=start,
-                    end=end,
+                    end=i,
                     is_reference=False
                 )
+            i += 1
             continue
 
-        if state == State.REFERENCE:
-            if brackets.closed(c):
+        if state == _STATE_REFERENCE:
+            if c == '[':
+                bracket_depth += 1
+            elif c == ']':
+                bracket_depth -= 1
+            if bracket_depth == 0:
                 # end of a complete reference-style link
-                end = i
-                raw_location = s[location: end]
+                raw_location = s[location: i]
                 return Link(
                     raw_location=raw_location,
                     parsed_location=_urlparse(raw_location),
                     alt_text=s[start + 1: location - 2],
                     title="",
                     start=start,
-                    end=end,
+                    end=i,
                     is_reference=True
                 )
+            i += 1
             continue
+
+        i += 1
 
     return None
 
@@ -239,9 +245,11 @@ def find_links(line: str) -> typing.List[Link]:
     Iteratively extract all links from a line.
     """
 
+    if '[' not in line:
+        return []
+
     results = []
-    index = 0
-    match = find_link(line, index)
+    match = find_link(line)
     while match:
         results.append(match)
         match = find_link(line, match.end + 1)

--- a/wikitools/link_parser.py
+++ b/wikitools/link_parser.py
@@ -7,7 +7,7 @@ from wikitools import console, reference_parser
 _urlparse = lru_cache(maxsize=4096)(parse.urlparse)
 
 
-# State constants inlined to avoid attribute lookups
+# Not an enum/class to avoid attribute lookups
 _STATE_IDLE = 0  # IDLE: jump to next '[' using optimized str.find
 _STATE_START = 1  # START: tracking bracket depth inline
 _STATE_INLINE = 2  # INLINE: tracking paren depth inline

--- a/wikitools/link_parser.py
+++ b/wikitools/link_parser.py
@@ -1,7 +1,10 @@
 import typing
+from functools import lru_cache
 from urllib import parse
 
 from wikitools import console, reference_parser
+
+_urlparse = lru_cache(maxsize=4096)(parse.urlparse)
 
 
 class Brackets():
@@ -203,7 +206,7 @@ def find_link(s: str, index=0) -> typing.Optional[Link]:
                 raw_location = s[location: extra]
                 return Link(
                     raw_location=raw_location,
-                    parsed_location=parse.urlparse(raw_location),
+                    parsed_location=_urlparse(raw_location),
                     alt_text=s[start + 1: location - 2],
                     title=s[extra: end],
                     start=start,
@@ -219,7 +222,7 @@ def find_link(s: str, index=0) -> typing.Optional[Link]:
                 raw_location = s[location: end]
                 return Link(
                     raw_location=raw_location,
-                    parsed_location=parse.urlparse(raw_location),
+                    parsed_location=_urlparse(raw_location),
                     alt_text=s[start + 1: location - 2],
                     title="",
                     start=start,

--- a/wikitools/link_parser.py
+++ b/wikitools/link_parser.py
@@ -149,7 +149,8 @@ def find_link(s: str, index=0) -> typing.Optional[Link]:
     parens = Brackets('(', ')')
     brackets = Brackets('[', ']')
 
-    for i in range(index, len(s)):
+    s_len = len(s)
+    for i in range(index, s_len):
         c = s[i]
         if state == State.IDLE and c == '[':
             # potential start of a link
@@ -160,7 +161,7 @@ def find_link(s: str, index=0) -> typing.Optional[Link]:
 
         if state == State.START:
             if brackets.closed(c):
-                if len(s) <= i + 1:
+                if s_len <= i + 1:
                     # end of the line
                     state = State.IDLE
                     continue


### PR DESCRIPTION
profile collected with:

```sh
cat > /tmp/profile_link_checker.py <<EOF
import sys
import os
import cProfile
import pstats

# Use the same venv
sys.path.insert(0, os.path.expanduser("~/stuffs/osu-wiki-tools"))
os.chdir(os.path.expanduser("~/stuffs/osu-wiki-tools"))

from wikitools_cli.commands.check_links import main

pr = cProfile.Profile()
pr.enable()
main("--all", "--root", os.path.expanduser("~/stuffs/osu-wiki"))
pr.disable()

stats = pstats.Stats(pr)
print("\n=== by total CPU time ===\n")
stats.sort_stats("tottime")
stats.print_stats(40)
print("\n=== by cumulative time ===\n")
stats.sort_stats("cumulative")
stats.print_stats(40)
EOF

_clear_cache() {
    find ~/stuffs/osu-wiki-tools -type d -name __pycache__ -exec rm -rf {} +
}

_clear_cache
uv venv ~/stuffs/osu-wiki-tools/.venv
uv pip install --python ~/stuffs/osu-wiki-tools/.venv/bin/python -e .
~/stuffs/osu-wiki-tools/.venv/bin/python /tmp/profile_link_checker.py


_clear_cache
echo "=== time without the profiler:"
time ~/stuffs/osu-wiki-tools/.venv/bin/osu-wiki-tools check-links --all --root ~/stuffs/osu-wiki
```

before:

```
Using CPython 3.13.7 interpreter at: /opt/homebrew/opt/python@3.13/bin/python3.13
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
Resolved 6 packages in 87ms
Installed 6 packages in 16ms
 + braceexpand==0.1.7
 + osu-wiki-tools==2.4.2 (from file:///Users/xxx/stuffs/osu-wiki-tools)
 + pathspec==1.0.4
 + pyyaml==6.0.1
 + types-pyyaml==6.0.12.12
 + yamllint==1.33.0
Notice: No broken wiki or image links detected.

Note: Found 0 errors in 0 files (384063 links in 5854 files checked).

=== by total CPU time ===

         163337624 function calls (163283722 primitive calls) in 42.395 seconds

   Ordered by: internal time
   List reduced from 511 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  1344695    7.605    0.000   12.320    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_parser.py:132(find_link)
   848234    5.604    0.000    8.438    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/code_block_parser.py:55(parse)
71281067/71264568    3.033    0.000    3.035    0.000 {built-in method builtins.len}
     6942    2.430    0.000    2.487    0.000 {built-in method _io.open}
   176929    1.886    0.000    1.886    0.000 {built-in method posix.getcwd}
   829726    1.849    0.000    2.421    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/identifier_parser.py:28(extract_identifier)
     6941    1.722    0.000   31.572    0.005 /Users/xxx/stuffs/osu-wiki-tools/wikitools/article_parser.py:159(parse)
 25740291    1.667    0.000    1.667    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_parser.py:18(closed)
   298359    0.921    0.000    1.803    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/parse.py:469(urlsplit)
     9162    0.828    0.000    0.828    0.000 {built-in method posix.scandir}
     6941    0.806    0.000    2.838    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/article_parser.py:98(load_front_matter)
   384063    0.715    0.000    9.861    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_checker.py:149(check_link)
   486898    0.617    0.000    1.044    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:257(_parse_path)
   834694    0.484    0.000    2.486    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:227(__str__)
   829514    0.432    0.000    0.700    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:117(__init__)
   470198    0.410    0.000    2.667    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/parse.py:374(urlparse)
  4425211    0.380    0.000    0.380    0.000 {method 'startswith' of 'str' objects}
  4781791    0.364    0.000    0.369    0.000 {built-in method builtins.isinstance}
    90518    0.364    0.000    0.365    0.000 {built-in method builtins.next}
   768557    0.338    0.000    0.387    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/parse.py:119(_coerce_args)
   502035    0.337    0.000    1.589    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:289(drive)
   878694    0.330    0.000   12.690    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_parser.py:233(find_links)
   384063    0.275    0.000    1.173    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_checker.py:62(get_repo_path)
  2485958    0.264    0.000    0.264    0.000 {built-in method __new__ of type object at 0x100d13cf0}
   829514    0.258    0.000    0.958    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:498(__init__)
   332711    0.233    0.000    0.545    0.000 <frozen posixpath>:176(dirname)
  3065845    0.229    0.000    0.315    0.000 {built-in method posix.fspath}
  2043542    0.224    0.000    0.224    0.000 {built-in method sys.intern}
   466001    0.223    0.000    0.333    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/article_parser.py:186(<lambda>)
  1981075    0.218    0.000    0.218    0.000 {method 'find' of 'str' objects}
  2484600    0.215    0.000    0.215    0.000 {method 'replace' of 'str' objects}
   271468    0.200    0.000    0.310    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/parse.py:413(_splitnetloc)
   848234    0.196    0.000    0.316    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/comment_parser.py:46(parse)
   506168    0.184    0.000    0.373    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:237(_format_parsed_parts)
   243909    0.183    0.000    0.311    0.000 <frozen posixpath>:72(join)
    88464    0.174    0.000    2.699    0.000 <frozen posixpath>:502(relpath)
   829514    0.169    0.000    0.248    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:505(__new__)
   488594    0.166    0.000    2.573    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_abc.py:142(as_posix)
  2689390    0.161    0.000    0.161    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_parser.py:9(__init__)
   601254    0.161    0.000    0.287    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/scanner.py:145(need_more_tokens)



=== by cumulative time ===

         163337624 function calls (163283722 primitive calls) in 42.395 seconds

   Ordered by: cumulative time
   List reduced from 511 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.027    0.027   42.674   42.674 /Users/xxx/stuffs/osu-wiki-tools/wikitools_cli/commands/check_links.py:103(main)
     6941    1.722    0.000   31.572    0.005 /Users/xxx/stuffs/osu-wiki-tools/wikitools/article_parser.py:159(parse)
   878694    0.330    0.000   12.690    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_parser.py:233(find_links)
  1344695    7.605    0.000   12.320    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_parser.py:132(find_link)
     5854    0.111    0.000   10.110    0.002 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_checker.py:283(check_article)
   607560    0.138    0.000    9.999    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_checker.py:295(<genexpr>)
   384063    0.715    0.000    9.861    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_checker.py:149(check_link)
   848234    5.604    0.000    8.438    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/code_block_parser.py:55(parse)
    82041    0.087    0.000    3.815    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/file_utils.py:64(exists_case_insensitive)
71281067/71264568    3.033    0.000    3.035    0.000 {built-in method builtins.len}
     6941    0.806    0.000    2.838    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/article_parser.py:98(load_front_matter)
    88464    0.174    0.000    2.699    0.000 <frozen posixpath>:502(relpath)
   470198    0.410    0.000    2.667    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/parse.py:374(urlparse)
   488594    0.166    0.000    2.573    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_abc.py:142(as_posix)
     6941    0.003    0.000    2.491    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:529(open)
     6942    2.430    0.000    2.487    0.000 {built-in method _io.open}
   834694    0.484    0.000    2.486    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:227(__str__)
   829726    1.849    0.000    2.421    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/identifier_parser.py:28(extract_identifier)
   176928    0.144    0.000    2.338    0.000 <frozen posixpath>:376(abspath)
     5425    0.004    0.000    1.976    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/__init__.py:117(safe_load)
     5425    0.008    0.000    1.973    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/__init__.py:74(load)
     5425    0.003    0.000    1.925    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/constructor.py:47(get_single_data)
   176929    1.886    0.000    1.886    0.000 {built-in method posix.getcwd}
     5425    0.006    0.000    1.814    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/composer.py:29(get_single_node)
   298359    0.921    0.000    1.803    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/parse.py:469(urlsplit)
 25740291    1.667    0.000    1.667    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_parser.py:18(closed)
     5425    0.004    0.000    1.662    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/composer.py:50(compose_document)
42749/5425    0.049    0.000    1.646    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/composer.py:63(compose_node)
   141143    0.043    0.000    1.606    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/parser.py:94(check_event)
   502035    0.337    0.000    1.589    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:289(drive)
     5425    0.018    0.000    1.415    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/composer.py:117(compose_mapping_node)
     9166    0.047    0.000    1.288    0.000 <frozen os>:289(walk)
   366155    0.137    0.000    1.255    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/scanner.py:113(check_token)
   384063    0.275    0.000    1.173    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_checker.py:62(get_repo_path)
    41747    0.016    0.000    1.051    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/file_utils.py:109(list_all_files)
   486898    0.617    0.000    1.044    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:257(_parse_path)
   829514    0.258    0.000    0.958    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:498(__init__)
     6942    0.009    0.000    0.888    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/file_utils.py:157(list_all_articles_and_newsposts)
    69518    0.086    0.000    0.879    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/scanner.py:156(fetch_more_tokens)
     9162    0.828    0.000    0.828    0.000 {built-in method posix.scandir}


=== time without the profiler:
Notice: No broken wiki or image links detected.

Note: Found 0 errors in 0 files (384063 links in 5854 files checked).
~/stuffs/osu-wiki-tools/.venv/bin/osu-wiki-tools check-links --all --root   16.25s user 2.34s system 83% cpu 22.397 total
```

after:

```
Using CPython 3.13.7 interpreter at: /opt/homebrew/opt/python@3.13/bin/python3.13
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
Resolved 6 packages in 88ms
Installed 6 packages in 13ms
 + braceexpand==0.1.7
 + osu-wiki-tools==2.4.2 (from file:///Users/xxx/stuffs/osu-wiki-tools)
 + pathspec==1.0.4
 + pyyaml==6.0.1
 + types-pyyaml==6.0.12.12
 + yamllint==1.33.0
Notice: No broken wiki or image links detected.

Note: Found 0 errors in 0 files (384063 links in 5854 files checked).

=== by total CPU time ===

         61224533 function calls (61170631 primitive calls) in 25.464 seconds

   Ordered by: internal time
   List reduced from 506 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   739077    3.181    0.000    4.575    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_parser.py:114(find_link)
   848234    2.441    0.000    2.615    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/code_block_parser.py:55(parse)
     6942    2.216    0.000    2.274    0.000 {built-in method _io.open}
   829726    1.816    0.000    2.248    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/identifier_parser.py:28(extract_identifier)
     6941    1.661    0.000   17.758    0.003 /Users/xxx/stuffs/osu-wiki-tools/wikitools/article_parser.py:159(parse)
     6941    0.885    0.000    3.006    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/article_parser.py:98(load_front_matter)
     9162    0.814    0.000    0.814    0.000 {built-in method posix.scandir}
   384063    0.660    0.000    6.694    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_checker.py:149(check_link)
   486898    0.587    0.000    0.979    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:257(_parse_path)
   154535    0.447    0.000    0.909    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/parse.py:469(urlsplit)
   834694    0.437    0.000    2.308    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:227(__str__)
   829514    0.409    0.000    0.665    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:117(__init__)
    90518    0.378    0.000    0.378    0.000 {built-in method builtins.next}
  4071355    0.328    0.000    0.328    0.000 {method 'startswith' of 'str' objects}
   878694    0.319    0.000    4.933    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_parser.py:243(find_links)
   502035    0.306    0.000    1.482    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:289(drive)
  3794527    0.279    0.000    0.284    0.000 {built-in method builtins.isinstance}
5728996/5712497    0.277    0.000    0.280    0.000 {built-in method builtins.len}
   384063    0.252    0.000    1.087    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_checker.py:62(get_repo_path)
   829514    0.238    0.000    0.903    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:498(__init__)
   332711    0.227    0.000    0.519    0.000 <frozen posixpath>:176(dirname)
  2202935    0.226    0.000    0.226    0.000 {method 'find' of 'str' objects}
  2029478    0.207    0.000    0.207    0.000 {built-in method __new__ of type object at 0x103967cf0}
  2043542    0.200    0.000    0.200    0.000 {built-in method sys.intern}
   466001    0.193    0.000    0.296    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/article_parser.py:186(<lambda>)
   848234    0.187    0.000    0.299    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/comment_parser.py:46(parse)
  2446597    0.179    0.000    0.257    0.000 {built-in method posix.fspath}
   506168    0.172    0.000    0.352    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:237(_format_parsed_parts)
   601254    0.164    0.000    0.285    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/scanner.py:145(need_more_tokens)
   157542    0.158    0.000    1.172    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/parse.py:374(urlparse)
   488594    0.156    0.000    2.389    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_abc.py:142(as_posix)
   829514    0.155    0.000    0.233    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:505(__new__)
  1687213    0.151    0.000    0.151    0.000 {method 'append' of 'list' objects}
   983648    0.142    0.000    0.178    0.000 {method 'join' of 'str' objects}
  1621656    0.140    0.000    0.140    0.000 {method 'replace' of 'str' objects}
    33645    0.139    0.000    0.401    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/scanner.py:1270(scan_plain)
   366155    0.138    0.000    1.339    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/scanner.py:113(check_token)
    13588    0.131    0.000    0.157    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/scanner.py:545(fetch_value)
   607560    0.124    0.000    6.818    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_checker.py:295(<genexpr>)
   486898    0.123    0.000    0.196    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:277(_raw_path)



=== by cumulative time ===

         61224533 function calls (61170631 primitive calls) in 25.464 seconds

   Ordered by: cumulative time
   List reduced from 506 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.026    0.026   25.659   25.659 /Users/xxx/stuffs/osu-wiki-tools/wikitools_cli/commands/check_links.py:103(main)
     6941    1.661    0.000   17.758    0.003 /Users/xxx/stuffs/osu-wiki-tools/wikitools/article_parser.py:159(parse)
     5854    0.096    0.000    6.915    0.001 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_checker.py:283(check_article)
   607560    0.124    0.000    6.818    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_checker.py:295(<genexpr>)
   384063    0.660    0.000    6.694    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_checker.py:149(check_link)
   878694    0.319    0.000    4.933    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_parser.py:243(find_links)
   739077    3.181    0.000    4.575    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_parser.py:114(find_link)
     6941    0.885    0.000    3.006    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/article_parser.py:98(load_front_matter)
   848234    2.441    0.000    2.615    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/code_block_parser.py:55(parse)
   488594    0.156    0.000    2.389    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_abc.py:142(as_posix)
   834694    0.437    0.000    2.308    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:227(__str__)
     6941    0.004    0.000    2.278    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:529(open)
     6942    2.216    0.000    2.274    0.000 {built-in method _io.open}
   829726    1.816    0.000    2.248    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/identifier_parser.py:28(extract_identifier)
     5425    0.004    0.000    2.066    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/__init__.py:117(safe_load)
     5425    0.008    0.000    2.062    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/__init__.py:74(load)
     5425    0.003    0.000    2.013    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/constructor.py:47(get_single_data)
     5425    0.006    0.000    1.901    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/composer.py:29(get_single_node)
     5425    0.004    0.000    1.745    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/composer.py:50(compose_document)
42749/5425    0.051    0.000    1.729    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/composer.py:63(compose_node)
   141143    0.043    0.000    1.690    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/parser.py:94(check_event)
   502035    0.306    0.000    1.482    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:289(drive)
     5425    0.019    0.000    1.391    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/composer.py:117(compose_mapping_node)
   366155    0.138    0.000    1.339    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/scanner.py:113(check_token)
     9166    0.048    0.000    1.297    0.000 <frozen os>:289(walk)
    82041    0.055    0.000    1.234    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/file_utils.py:64(exists_case_insensitive)
   157542    0.158    0.000    1.172    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/parse.py:374(urlparse)
   384063    0.252    0.000    1.087    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/link_checker.py:62(get_repo_path)
    41747    0.016    0.000    1.047    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/file_utils.py:109(list_all_files)
   486898    0.587    0.000    0.979    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:257(_parse_path)
    69518    0.085    0.000    0.966    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/scanner.py:156(fetch_more_tokens)
   154535    0.447    0.000    0.909    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/urllib/parse.py:469(urlsplit)
   829514    0.238    0.000    0.903    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:498(__init__)
     6942    0.009    0.000    0.889    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/file_utils.py:157(list_all_articles_and_newsposts)
     9162    0.814    0.000    0.814    0.000 {built-in method posix.scandir}
    88464    0.039    0.000    0.690    0.000 /Users/xxx/stuffs/osu-wiki-tools/wikitools/file_utils.py:32(file_tree)
   829514    0.409    0.000    0.665    0.000 /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py:117(__init__)
   332711    0.227    0.000    0.519    0.000 <frozen posixpath>:176(dirname)
    33645    0.018    0.000    0.460    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/scanner.py:668(fetch_plain)
    13588    0.011    0.000    0.441    0.000 /Users/xxx/stuffs/osu-wiki-tools/.venv/lib/python3.13/site-packages/yaml/parser.py:446(parse_block_mapping_value)

=== time without the profiler:
Notice: No broken wiki or image links detected.

Note: Found 0 errors in 0 files (384063 links in 5854 files checked).
~/stuffs/osu-wiki-tools/.venv/bin/osu-wiki-tools check-links --all --root   11.06s user 0.76s system 74% cpu 15.789 total
```